### PR TITLE
BNPieChart.m: an addition to the pie chart initialization

### DIFF
--- a/BNPieChart.m
+++ b/BNPieChart.m
@@ -51,21 +51,31 @@
 	return chart;
 }
 
-- (id)initWithFrame:(CGRect)frame {
-  if (self = [super initWithFrame:frame]) {
+- (void) initInstance {
     // Initialization code
-		self.backgroundColor = [UIColor clearColor];
-		self.opaque = NO;
-		self.slicePortions = [NSMutableArray new];
-		slicePointsIn01 = [[NSMutableArray alloc]
+    self.backgroundColor = [UIColor clearColor];
+    self.opaque = NO;
+    self.slicePortions = [NSMutableArray new];
+    slicePointsIn01 = [[NSMutableArray alloc]
                        initWithObjects:nFloat(0.0), nil];
-		sliceNames = [NSMutableArray new];
-		nameLabels = [NSMutableArray new];
-		colorspace = CGColorSpaceCreateDeviceRGB();
-    
-    self.frame = frame;
-  }
-  return self;
+    sliceNames = [NSMutableArray new];
+    nameLabels = [NSMutableArray new];
+    colorspace = CGColorSpaceCreateDeviceRGB();    
+}
+
+- (id)initWithFrame:(CGRect)frame {
+    if ((self = [super initWithFrame:frame])) {
+        [self initInstance];
+        self.frame = frame;    
+    }
+    return self;
+}
+
+- (id)initWithCoder:(NSCoder *)aDecoder {
+    if ((self = [super initWithCoder: aDecoder])) {
+        [self initInstance];
+    }
+    return self;
 }
 
 - (void)dealloc {


### PR DESCRIPTION
Just tried to add a BNPieChart from nib (creating an UIView of the class BNPieChart) and noticed that it breaks because of not running through the proper initialization: initWithCoder got called instead of initWithFrame. I have refactored the initialitzation code in a private message initInstance, added initWithCoder and called initialization from both constructors. Now it works okay both from code and nib, so I have committed the changes and it's up to you to take it.
