### PR TITLE
neutral refactorings to silence Xcode 4.5.2 warnings

### DIFF
--- a/CodeTimestamps.m
+++ b/CodeTimestamps.m
@@ -183,9 +183,9 @@ void LogTimestampChunkInMethod(const char *fnName, int lineNum, BOOL isStart, BO
       [chunkData sortUsingSelector:@selector(compare:)];
       NSThread *thread = nil;
       NSMutableArray *timeIntervals = [NSMutableArray array];
-      uint64_t totalNanoSecsThisChunk;
-      uint64_t totalNanoSecsThisThread;
-      int numRunsThisThread;
+      uint64_t totalNanoSecsThisChunk=0;
+      uint64_t totalNanoSecsThisThread=0;
+      int numRunsThisThread=0;
       BOOL thisThreadHadChunks = NO;
       BOOL midChunk = NO;
       ChunkStamp *lastStamp = nil;

--- a/CodeTimestamps.m
+++ b/CodeTimestamps.m
@@ -213,7 +213,8 @@ void LogTimestampChunkInMethod(const char *fnName, int lineNum, BOOL isStart, BO
           midChunk = YES;
           thisThreadHadChunks = YES;
           chunkName = [NSString stringWithFormat:@"%s:%d", chunkStamp->fnName, chunkStamp->lineNum];
-        } else if (midChunk) {
+        }
+        else if (midChunk) {
           ChunkTimeInterval *timeInterval = [[[ChunkTimeInterval alloc] initFromStamp:lastStamp toStamp:chunkStamp] autorelease];
           [timeIntervals addObject:timeInterval];
           totalNanoSecsThisChunk += timeInterval->nanoSecsElapsed;
@@ -242,7 +243,7 @@ void LogTimestampChunkInMethod(const char *fnName, int lineNum, BOOL isStart, BO
         }
         lastStamp = chunkStamp;
       }
-      if (thisThreadHadChunks) {
+      if (thisThreadHadChunks && (numRunsThisThread != 0)) {
         NSLog(@"++ Chunk = %@, avg time = %lld nsec", chunkName,
               totalNanoSecsThisThread / numRunsThisThread);
       }

--- a/CodeTimestamps.m
+++ b/CodeTimestamps.m
@@ -243,7 +243,7 @@ void LogTimestampChunkInMethod(const char *fnName, int lineNum, BOOL isStart, BO
         lastStamp = chunkStamp;
       }
       if (thisThreadHadChunks) {
-        NSLog(@"++ Chunk = %@, avg time = %d nsec", chunkName,
+        NSLog(@"++ Chunk = %@, avg time = %lld nsec", chunkName,
               totalNanoSecsThisThread / numRunsThisThread);
       }
       [chunkData removeAllObjects];

--- a/CodeTimestamps.m
+++ b/CodeTimestamps.m
@@ -194,7 +194,7 @@ void LogTimestampChunkInMethod(const char *fnName, int lineNum, BOOL isStart, BO
         if (chunkStamp->thread != thread) {
           if (thisThreadHadChunks) {
             NSLog(@"++ Chunk = %@, avg time = %.4fs", chunkName,
-                  (float)totalNanoSecsThisThread / numRunsThisThread / 1e9);
+                  ((float)totalNanoSecsThisThread / numRunsThisThread) / 1e9);
           }
           
           thread = chunkStamp->thread;

--- a/CodeTimestamps.m
+++ b/CodeTimestamps.m
@@ -123,10 +123,12 @@ void LogTimestampChunkInMethod(const char *fnName, int lineNum, BOOL isStart, BO
 
 @implementation ChunkTimeInterval
 - (id)initFromStamp:(ChunkStamp *)stamp1 toStamp:(ChunkStamp *)stamp2 {
-  if (![super init]) return nil;
-  intervalName = [[NSString stringWithFormat:@"%s:%d - %s:%d",
-                   stamp1->fnName, stamp1->lineNum, stamp2->fnName, stamp2->lineNum] retain];
-  nanoSecsElapsed = NanosecondsFromTimeInterval(stamp2->timestamp - stamp1->timestamp);
+  self = [super init];
+  if (self) {
+    intervalName = [[NSString stringWithFormat:@"%s:%d - %s:%d",
+                     stamp1->fnName, stamp1->lineNum, stamp2->fnName, stamp2->lineNum] retain];
+    nanoSecsElapsed = NanosecondsFromTimeInterval(stamp2->timestamp - stamp1->timestamp);
+  }
   return self;
 }
 - (void)dealloc {
@@ -149,9 +151,11 @@ void LogTimestampChunkInMethod(const char *fnName, int lineNum, BOOL isStart, BO
 }
 
 - (id)init {
-  if (![super init]) return nil;
-  pendingLines = [NSMutableArray new];
-  slowestChunks = [NSMutableArray new];
+  self = [super init];
+  if (self) {
+    pendingLines = [NSMutableArray new];
+    slowestChunks = [NSMutableArray new];
+  }
   return self;
 }
 

--- a/CodeTimestamps.m
+++ b/CodeTimestamps.m
@@ -225,9 +225,9 @@ void LogTimestampChunkInMethod(const char *fnName, int lineNum, BOOL isStart, BO
             
             [self consolidateTimeIntervals:timeIntervals];
             for (int i = 0; i < [timeIntervals count] && i < kNumMidPoints; ++i) {
-              ChunkTimeInterval *timeInterval = [timeIntervals objectAtIndex:i];
-              int percentTime = (int)round(100.0 * (float)timeInterval->nanoSecsElapsed / totalNanoSecsThisChunk);
-              NSLog(@"    %2d%% in %@", percentTime, timeInterval->intervalName);
+              ChunkTimeInterval *individualTimeInterval = [timeIntervals objectAtIndex:i];
+              int percentTime = (int)round(100.0 * (float)individualTimeInterval->nanoSecsElapsed / totalNanoSecsThisChunk);
+              NSLog(@"    %2d%% in %@", percentTime, individualTimeInterval->intervalName);
             }
             
             ChunkTimeInterval *totalInterval = [[ChunkTimeInterval new] autorelease];


### PR DESCRIPTION
These changes silence compiler warnings by fixing small bugs or clarifying the code to help the static analyzer.

Fixes:
- initialized some function local variable at their declaration
- corrected a NSLog format specifier

hints:
- use standard Obj-C idiom to initialize ivars
- rename  local vars so they don't shadow vars from the enclosing scope
- enhance conditional to silence warning about div-by-zero
